### PR TITLE
Allow error reporting.

### DIFF
--- a/src/com/ingotpowered/api/plugins/Plugin.java
+++ b/src/com/ingotpowered/api/plugins/Plugin.java
@@ -33,4 +33,7 @@ public abstract class Plugin {
     public File getPluginDirectory() {
         return pluginDirectory;
     }
+
+    public void handleException(Exception ex){
+    }
 }


### PR DESCRIPTION
Allow any errors from events, plugin starts or stops, or any scheduled tasks to be reported back to the plugin. This is to allow for remote error reporting. (Maybe a pastebin post, or app.gensentry.com report).
